### PR TITLE
Fix variable name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/sh
-fW_DIR	:= /lib/firmware/rtl_bt/
+FW_DIR	:= /lib/firmware/rtl_bt/
 MDL_DIR	:= /lib/modules/$(shell uname -r)
 DRV_DIR	:= $(MDL_DIR)/kernel/drivers/bluetooth
 


### PR DESCRIPTION
It fixes this error:
```
rmn@yoga:/opt/kernel_mods/rtl8723au_bt$ sudo make install
[sudo] password for rmn: 
mkdir: missing operand
Try 'mkdir --help' for more information.
make: *** [install] Error 1
```