### PR TITLE
Add rtl8723bu to device list

### DIFF
--- a/btusb.c
+++ b/btusb.c
@@ -323,6 +323,11 @@ static const struct usb_device_id blacklist_table[] = {
 	{ USB_DEVICE(0x13d3, 0x3416), .driver_info = BTUSB_REALTEK },
 	{ USB_DEVICE(0x13d3, 0x3459), .driver_info = BTUSB_REALTEK },
 
+	/* Additional Realtek 8723BU Bluetooth devices */
+	{ USB_DEVICE(0x0bda, 0xb720), .driver_info = BTUSB_REALTEK },
+	{ USB_DEVICE(0x0bda, 0xb72a), .driver_info = BTUSB_REALTEK },
+	{ USB_DEVICE(0x7392, 0xa611), .driver_info = BTUSB_REALTEK }, // EDIMAX EW-7611ULB
+	
 	/* Additional Realtek 8821AE Bluetooth devices */
 	{ USB_DEVICE(0x0b05, 0x17dc), .driver_info = BTUSB_REALTEK },
 	{ USB_DEVICE(0x13d3, 0x3414), .driver_info = BTUSB_REALTEK },


### PR DESCRIPTION
Added two devices from @ferbar's patch on #51 and my EDIMAX EW-7611ULB.  Confirmed working with the EW-7611ULB on Debian Sid, 4.9.0-2-amd64 all the way through listening to music over A2DP.  It's choppy like most WiFi/BT all-in-ones, but it works.