### PR TITLE
skb_put  changed from (unsigned char*) to (void *)

### DIFF
--- a/btusb.c
+++ b/btusb.c
@@ -1744,7 +1744,7 @@ static int inject_cmd_complete(struct hci_dev *hdev, __u16 opcode)
 	evt->ncmd = 0x01;
 	evt->opcode = cpu_to_le16(opcode);
 
-	*skb_put(skb, 1) = 0x00;
+	*(u8 *)skb_put(skb, 1) = 0x00;
 
 	bt_cb(skb)->pkt_type = HCI_EVENT_PKT;
 


### PR DESCRIPTION
The latest patch does work when you realize that the skb_put function has recently changed from (unsigned char*) to (void *) ( see https://patchwork.ozlabs.org/patch/776580/ for fix).